### PR TITLE
fix: Fix "Debug UI Tests" by Replacing a `glob` Pattern, and Adding Configuration for Windows Machine

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
       "program": "${workspaceFolder}/node_modules/.bin/extest",
       "args": [
         "setup-and-run",
-        "${workspaceFolder}/out/ui-test/*-test.js",
+        "${workspaceFolder}/out/ui-test/*.test.js",
         "--code_settings",
         "settings.json",
         "--extensions_dir",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,9 @@
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/.bin/extest",
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/vscode-extension-tester/out/cli.js",
+      },
       "args": [
         "setup-and-run",
         "${workspaceFolder}/out/ui-test/*.test.js",


### PR DESCRIPTION
## Abstract

Fixed "Debug UI Tests" by:
- Replacing a `glob` pattern
- Adding configuration for Windows machines

## Expected / Actual

- **Expected**: "Debug UI Tests" runs all the test cases in `out/ui-tests/*.test.js`
- **Actual**: "Debug UI Tests" runs none of the test cases

## Causes

- The `glob` pattern specified in `launch.json` does not matche any test cases
- Shebang sometimes does not work on Windows machines. For more information, refer to [vscode-extension-tester/wiki/Debugging-Tests](https://github.com/redhat-developer/vscode-extension-tester/wiki/Debugging-Tests)
